### PR TITLE
Fix library occupancy parsing

### DIFF
--- a/electron/api.js
+++ b/electron/api.js
@@ -46,7 +46,7 @@ function startApiServer() {
         const match1 = html.match(regex1);
         const regex2 = /<span\s+style="color:red;font-size:150px">(\d+)<\/span>/;
         const match2 = html.match(regex2);
-        if (match1 && match1) {
+        if (match1 && match2) {
           libraryData.currentCount = match1[1];
           libraryData.remainingCount = match2[1];
         } else {


### PR DESCRIPTION
## Summary
- fix logic for occupancy regex matches in api server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fb935c0a88321a78b57994488c67c