### PR TITLE
Fix floor progress status for 7th floor

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -258,7 +258,7 @@ onMounted(() => {
             <div class="floor-item">
               <span>7楼</span>
               <el-progress :percentage="_7fPer" :text-inside="true" :stroke-width="14"
-              :status="_7fPer > 70 ? 'exception' : _6fPer > 50 ? 'warning' : 'success'" />
+                :status="_7fPer > 70 ? 'exception' : _7fPer > 50 ? 'warning' : 'success'" />
             </div>
           </div>
         </el-col>


### PR DESCRIPTION
## Summary
- fix mis-referenced variable in 7th floor progress bar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fb91ecb7c8321bc26e2c3546c6393