### PR TITLE
Implement reservation task persistence

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -14,6 +14,7 @@ const {
 } = require('./services/dbService.js');
 
 const { updateSeatMenuDatabase, updateSeatCountDatabase, updateSeatListDatabase } = require('./services/updateSeatMenuDatabaseService.js');
+const taskService = require('./services/taskService.js');
 
 // The built directory structure
 //
@@ -111,6 +112,39 @@ ipcMain.handle('get-user-credit', async () => {
 
 ipcMain.handle('get-app-version', () => {
   return app.getVersion()
+})
+
+ipcMain.handle('task:save', (_event, task) => {
+  try {
+    taskService.saveTask(task)
+    taskService.appendLog('创建预约任务')
+    return { success: true }
+  } catch (err) {
+    console.error('save task error:', err)
+    return { success: false, message: err.message }
+  }
+})
+
+ipcMain.handle('task:load', () => {
+  try {
+    const data = taskService.loadTask()
+    const log = taskService.readLog()
+    return { success: true, data, log }
+  } catch (err) {
+    console.error('load task error:', err)
+    return { success: false, message: err.message }
+  }
+})
+
+ipcMain.handle('task:delete', () => {
+  try {
+    taskService.deleteTask()
+    taskService.appendLog('删除预约任务')
+    return { success: true }
+  } catch (err) {
+    console.error('delete task error:', err)
+    return { success: false, message: err.message }
+  }
 })
 
 let win = null;

--- a/electron/services/taskService.js
+++ b/electron/services/taskService.js
@@ -24,13 +24,15 @@ function deleteTask() {
 }
 
 function appendLog(content) {
-  const line = `[${new Date().toISOString()}] ${content}\n`;
+  const line = `[${new Date().toLocaleString('zh-CN', { hour12: false })}] ${content}\n`;
   fs.appendFileSync(LOG_FILE, line, 'utf-8');
 }
 
 function readLog() {
   if (fs.existsSync(LOG_FILE)) {
-    return fs.readFileSync(LOG_FILE, 'utf-8');
+    const logContent = fs.readFileSync(LOG_FILE, 'utf-8');
+    const logLines = logContent.split('\n').reverse().slice(1, 50);
+    return logLines.join('\n');
   }
   return '';
 }

--- a/electron/services/taskService.js
+++ b/electron/services/taskService.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { app } = require('electron');
+
+const dataPath = app.getPath('userData');
+const TASK_FILE = path.join(dataPath, 'reservation-task.json');
+const LOG_FILE = path.join(dataPath, 'reservation.log');
+
+function saveTask(task) {
+  fs.writeFileSync(TASK_FILE, JSON.stringify(task, null, 2), 'utf-8');
+}
+
+function loadTask() {
+  if (fs.existsSync(TASK_FILE)) {
+    return JSON.parse(fs.readFileSync(TASK_FILE, 'utf-8'));
+  }
+  return null;
+}
+
+function deleteTask() {
+  if (fs.existsSync(TASK_FILE)) {
+    fs.unlinkSync(TASK_FILE);
+  }
+}
+
+function appendLog(content) {
+  const line = `[${new Date().toISOString()}] ${content}\n`;
+  fs.appendFileSync(LOG_FILE, line, 'utf-8');
+}
+
+function readLog() {
+  if (fs.existsSync(LOG_FILE)) {
+    return fs.readFileSync(LOG_FILE, 'utf-8');
+  }
+  return '';
+}
+
+module.exports = {
+  saveTask,
+  loadTask,
+  deleteTask,
+  appendLog,
+  readLog,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -24,9 +24,4 @@ for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
 app.use(createPinia())
 app.use(ElementPlus)
 app.use(router)
-app.mount('#app').$nextTick(() => {
-  // Use contextBridge
-  window.ipcRenderer.on('main-process-message', (_event, message) => {
-    console.log(message)
-  })
-})
+app.mount('#app');

--- a/src/views/Reservation.vue
+++ b/src/views/Reservation.vue
@@ -64,22 +64,39 @@ const clearResvSeatList = () => {
   ElMessage.success('清空成功')
 }
 
-const submitResvList = () => {
+const submitResvList = async () => {
   if (resvSeatIdList.value.length === 0) {
     ElMessage.warning('请先添加预选座位')
     return
   }
 
-  // 模拟提交成功
-  ElMessage.success('预约任务提交成功')
-  // 获取当前预约任务详情
-  getNowResvDetail()
+  const task = {
+    stuId: userStore.userInfo.logonName || userStore.userInfo.stu_id,
+    seatIds: resvSeatIdList.value,
+    seatNames: resvSeatNameList.value,
+    startTime: user.value.resv_start_time,
+    createdAt: new Date().toISOString().replace('T', ' ').substring(0, 19),
+    result: ''
+  }
+
+  const res = await window.api.invoke('task:save', task)
+  if (res.success) {
+    ElMessage.success('预约任务提交成功')
+    clearResvSeatList()
+    await getNowResvDetail()
+  } else {
+    ElMessage.error('任务保存失败: ' + res.message)
+  }
 }
 
-const deleteResvList = () => {
-  // 模拟删除成功
-  ElMessage.success('预约任务删除成功')
-  showNowResvDetail.value = false
+const deleteResvList = async () => {
+  const res = await window.api.invoke('task:delete')
+  if (res.success) {
+    ElMessage.success('预约任务删除成功')
+    showNowResvDetail.value = false
+  } else {
+    ElMessage.error('删除失败: ' + res.message)
+  }
 }
 
 const showSeatPDF = async () => {
@@ -93,23 +110,22 @@ const showSeatPDF = async () => {
   }
 }
 
-const getNowResvDetail = () => {
-  // 模拟获取当前预约任务详情
-  showNowResvDetail.value = true
-  taskStuId.value = '2020001'
-  taskCreateTime.value = '2023-06-01 10:00:00'
-  taskSeatNameList.value = resvSeatNameList.value.join(', ')
-  lastResvResult.value = '<p style="color:green">预约成功: A101</p>'
-  lastResvLog.value = '<p>2023-06-01 08:00:00 开始执行预约任务</p><p>2023-06-01 08:00:05 尝试预约座位 A101</p><p>2023-06-01 08:00:10 预约成功</p>'
+const getNowResvDetail = async () => {
+  const res = await window.api.invoke('task:load')
+  if (res.success && res.data) {
+    showNowResvDetail.value = true
+    taskStuId.value = res.data.stuId
+    taskCreateTime.value = res.data.createdAt
+    taskSeatNameList.value = res.data.seatNames.join(', ')
+    lastResvResult.value = res.data.result || ''
+    lastResvLog.value = res.log ? res.log.replace(/\n/g, '<br/>') : ''
+  } else {
+    showNowResvDetail.value = false
+  }
 }
 
 onMounted(() => {
-  // 检查是否有现有预约任务
-  // 模拟数据，实际应从API获取
-  const hasExistingTask = false
-  if (hasExistingTask) {
-    getNowResvDetail()
-  }
+  getNowResvDetail()
 })
 </script>
 

--- a/src/views/Reservation.vue
+++ b/src/views/Reservation.vue
@@ -60,8 +60,8 @@ const handleResvSeatSelect = (seat) => {
 const clearResvSeatList = () => {
   resvSeatIdList.value = []
   resvSeatNameList.value = []
+  resvSeatList.value = []
   showResvSelectList.value = false
-  ElMessage.success('清空成功')
 }
 
 const submitResvList = async () => {
@@ -71,14 +71,21 @@ const submitResvList = async () => {
   }
 
   const task = {
-    stuId: userStore.userInfo.logonName || userStore.userInfo.stu_id,
-    seatIds: resvSeatIdList.value,
-    seatNames: resvSeatNameList.value,
-    startTime: user.value.resv_start_time,
-    createdAt: new Date().toISOString().replace('T', ' ').substring(0, 19),
+    stuId: userStore.userInfo.logonName,
+    stuName: userStore.userInfo.trueName,
+    stuPwd: userStore.systemSetting.stu_pwd,
+    cookie: userStore.systemSetting.token,
+    userData: userStore.systemSetting.user_data,
+    seatList: resvSeatIdList.value.map((seatId, index) => ({
+      id: seatId.toString(),
+      name: resvSeatNameList.value[index].toString()
+    })),
+    startTime: user.value.resv_start_time || '8:00',
+    createdAt: new Date().toLocaleString('zh-CN', { hour12: false }),
     result: ''
   }
 
+  console.log('提交的预约任务:', task)
   const res = await window.api.invoke('task:save', task)
   if (res.success) {
     ElMessage.success('预约任务提交成功')
@@ -116,7 +123,7 @@ const getNowResvDetail = async () => {
     showNowResvDetail.value = true
     taskStuId.value = res.data.stuId
     taskCreateTime.value = res.data.createdAt
-    taskSeatNameList.value = res.data.seatNames.join(', ')
+    taskSeatNameList.value = res.data.seatList.map(seat => seat.name).join(', ')
     lastResvResult.value = res.data.result || ''
     lastResvLog.value = res.log ? res.log.replace(/\n/g, '<br/>') : ''
   } else {


### PR DESCRIPTION
## Summary
- add new `taskService` to handle task config in user data directory
- expose IPC handlers for saving/loading/deleting reservation tasks
- update Reservation.vue to persist task info and load execution log

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e776c5c88321a8c5df7ff6d2bd87